### PR TITLE
feat(DVO-2820): Github Token Migration [skip ci]

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -19,13 +19,21 @@ jobs:
     name: Validate PR title
     runs-on: ${{ fromJSON(vars.RUNS_ON) }}
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GIT_APP_ID }}
+          private-key: ${{ secrets.GIT_APP_PRIVATE_KEY }}
+          owner: SallaApp
+
       # skip on new commits and on body-only edits
       - if: >-
           github.event.action != 'synchronize' &&
           (github.event.action != 'edited' || github.event.changes.title != null)
         uses: SallaApp/.CI/lint-pr@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
   branch:
     name: Validate branch name


### PR DESCRIPTION
Completes the move off `secrets.GITHUB_TOKEN` in this repo's workflows.

**What changed**
- `secrets.GITHUB_TOKEN` reference in `lint-pr.yaml` now uses a GitHub App installation token minted in-workflow via `actions/create-github-app-token@v1` (`GIT_APP_ID` / `GIT_APP_PRIVATE_KEY`).
- The `title` job gets the token-generation step as its first step; the `branch` job is untouched since it never used a token.

**Note on behaviour** — `GITHUB_TOKEN` deliberately does not trigger new workflow runs; App installation tokens do. This job only posts PR title lint feedback, so no downstream workflow-trigger changes are expected.

**Before merging** the App needs: Pull requests: write, Issues: write, Metadata: read.

Part of DVO-2820.